### PR TITLE
Add an option to send feed's content to Readeck

### DIFF
--- a/Controllers/readeckButtonController.php
+++ b/Controllers/readeckButtonController.php
@@ -48,16 +48,15 @@ class FreshExtension_readeckButton_Controller extends Minz_ActionController
     FreshRSS_Context::userConf()->save();
 
     $result = $this->curlGetRequest('/profile');
+    $url_redirect = array('c' => 'extension', 'a' => 'configure', 'params' => array('e' => 'Readeck Button'));
     if ($result['status'] == 200) {
       FreshRSS_Context::userConf()->_attribute('readeck_username', $result['response']->user->username);
       FreshRSS_Context::userConf()->save();
 
-      $url_redirect = array('c' => 'extension', 'a' => 'configure', 'params' => array('e' => 'Readeck Button'));
       Minz_Request::good(_t('ext.readeckButton.notifications.authorized_success'), $url_redirect);
       return;
     }
 
-    $url_redirect = array('c' => 'extension', 'a' => 'configure', 'params' => array('e' => 'Readeck Button'));
     Minz_Request::bad(_t('ext.readeckButton.notifications.request_access_failed', $result['status']), $url_redirect);
   }
 
@@ -85,7 +84,16 @@ class FreshExtension_readeckButton_Controller extends Minz_ActionController
       return;
     }
 
-    $post_data = FreshRSS_Context::userConf()->attributeString("readeck_content") === "on"
+    $behavior = FreshRSS_Context::userConf()->attributeString("readeck_behavior");
+
+    // TO BE REMOVED:
+    // Update missing entry after update
+    if ($behavior == "") {
+      FreshRSS_Context::userConf()->_attribute('readeck_behavior', "smart");
+      FreshRSS_Context::userConf()->save();
+    }
+
+    $post_data = $this->shouldSendContent($entry->feed(), $behavior)
       ? array(
         'url' => $entry->link(),
         'html' => $entry->content(),
@@ -99,6 +107,47 @@ class FreshExtension_readeckButton_Controller extends Minz_ActionController
     $result = $this->curlPostRequest('/bookmarks', $post_data);
     $result['response'] = array('title' => $entry->title());
     echo json_encode($result);
+  }
+
+  private function shouldSendContent(FreshRSS_Feed $feed, string $behavior): bool
+  {
+    return $behavior === "content"
+      || ($behavior === "smart" && $this->isFeedAuthenticated($feed));
+  }
+
+  private function isFeedAuthenticated(FreshRSS_Feed $feed): bool
+  {
+    if ($feed->httpAuth(true) !== '') {
+      return true;
+    }
+
+    // TODO: tokens would be missed (tokens like X-API_KEY, ...)
+    // Check HTTP Headers
+    $curlParams = $feed->attributeArray('curl_params');
+    if (is_array($curlParams)) {
+      $httpHeaders = $curlParams[CURLOPT_HTTPHEADER] ?? null;
+      if (is_array($httpHeaders)) {
+        foreach ($httpHeaders as $header) {
+          if (is_string($header) && stripos($header, 'Authorization:') === 0) {
+            return true;
+          }
+        }
+      }
+    }
+
+    // Check URL params
+    $parts = parse_url($feed->url());
+    if (!empty($parts['query'])) {
+      $query = [];
+      parse_str($parts['query'], $query);
+      foreach (array_keys($query) as $queryParam) {
+        if (is_string($queryParam) && preg_match('/token|auth|access|key/i', $queryParam)) {
+          return true;
+        }
+      }
+    }
+
+    return false;
   }
 
   /**

--- a/Controllers/readeckButtonController.php
+++ b/Controllers/readeckButtonController.php
@@ -93,7 +93,7 @@ class FreshExtension_readeckButton_Controller extends Minz_ActionController
       FreshRSS_Context::userConf()->save();
     }
 
-    $post_data = $this->shouldSendContent($entry->feed(), $behavior)
+    $post_data = $this->shouldSendContent($entry, $behavior)
       ? array(
         'url' => $entry->link(),
         'html' => $entry->content(),
@@ -109,10 +109,15 @@ class FreshExtension_readeckButton_Controller extends Minz_ActionController
     echo json_encode($result);
   }
 
-  private function shouldSendContent(FreshRSS_Feed $feed, string $behavior): bool
+  private function shouldSendContent(FreshRSS_Entry $entry, string $behavior): bool
   {
+    if (trim($entry->link()) === "") {
+      // Force content behavior on entries without link
+      return true;
+    }
+
     return $behavior === "content"
-      || ($behavior === "smart" && $this->isFeedAuthenticated($feed));
+      || ($behavior === "smart" && $this->isFeedAuthenticated($entry->feed()));
   }
 
   private function isFeedAuthenticated(FreshRSS_Feed $feed): bool

--- a/Controllers/readeckButtonController.php
+++ b/Controllers/readeckButtonController.php
@@ -85,9 +85,15 @@ class FreshExtension_readeckButton_Controller extends Minz_ActionController
       return;
     }
 
-    $post_data = array(
-      'url' => $entry->link(),
-    );
+    $post_data = FreshRSS_Context::userConf()->attributeString("readeck_content") === "on"
+      ? array(
+        'url' => $entry->link(),
+        'html' => $entry->content(),
+        'title' => $entry->title(),
+      )
+      : array(
+        'url' => $entry->link(),
+      );
 
     // Errors are handled in the JS
     $result = $this->curlPostRequest('/bookmarks', $post_data);

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ With this extension you can simply press the Readeck Button next to an article o
 6. Enter your key in the Readeck Button extension settings
 7. Press "Connect to Readeck"
 8. *Optional Set a custom keyboard shortcut*
+8. *Optional Update the extension behavior*
 
 ## Readeck API Error codes
 If you get errors while trying to connect to Readeck, please check the [Readeck OpenAPI specification](https://codeberg.org/readeck/readeck/src/branch/main/docs/api/api.yaml).

--- a/configure.phtml
+++ b/configure.phtml
@@ -7,6 +7,7 @@ $api_token = FreshRSS_Context::userConf()->attributeString('readeck_api_token');
 $username = FreshRSS_Context::userConf()->attributeString('readeck_username');
 $keyboard_shortcut = FreshRSS_Context::userConf()->attributeString('readeck_shortcut');
 $button_location = FreshRSS_Context::userConf()->attributeString('readeck_button_location');
+$send_content = FreshRSS_Context::userConf()->attributeString("readeck_content");
 ?>
 
 <form action="<?= _url('extension', 'configure', 'e', urlencode($this->getName())); ?>" method="post">
@@ -27,6 +28,15 @@ $button_location = FreshRSS_Context::userConf()->attributeString('readeck_button
       </select>
     </div>
   </div>
+
+  <div class="form-group">
+    <label class="group-name" for="send_content"><?= _t('ext.readeckButton.configure.send_content'); ?></label>
+    <div class="group-controls">
+      <input type="checkbox" name="send_content" id="send_content" <?php echo ($send_content === "on" ? 'checked' : ''); ?> aria-describedby="send_content_description">
+    </div>
+    <p id="send_content_description"><?= _t('ext.readeckButton.configure.send_content_description'); ?></p>
+  </div>
+
   <div class="form-group form-actions">
     <div class="group-controls">
       <button type="submit" class="btn btn-important"><?= _t('ext.readeckButton.configure.save_changes'); ?></button>

--- a/configure.phtml
+++ b/configure.phtml
@@ -7,7 +7,7 @@ $api_token = FreshRSS_Context::userConf()->attributeString('readeck_api_token');
 $username = FreshRSS_Context::userConf()->attributeString('readeck_username');
 $keyboard_shortcut = FreshRSS_Context::userConf()->attributeString('readeck_shortcut');
 $button_location = FreshRSS_Context::userConf()->attributeString('readeck_button_location');
-$send_content = FreshRSS_Context::userConf()->attributeString("readeck_content");
+$behavior = FreshRSS_Context::userConf()->attributeString('readeck_behavior');
 ?>
 
 <form action="<?= _url('extension', 'configure', 'e', urlencode($this->getName())); ?>" method="post">
@@ -16,6 +16,16 @@ $send_content = FreshRSS_Context::userConf()->attributeString("readeck_content")
     <label class="group-name" for="readeck_shortcut"><?= _t('ext.readeckButton.configure.keyboard_shortcut'); ?></label>
     <div class="group-controls">
       <input type="text" name="readeck_shortcut" id="readeck_shortcut" maxlength="1" value="<?= $keyboard_shortcut; ?>">
+    </div>
+
+    <label class="group-name" for="readeck_behavior"><?= _t('ext.readeckButton.configure.behavior'); ?></label>
+    <div class="group-controls">
+      <select name="readeck_behavior" id="readeck_behavior" aria-describedby="behavior_description">
+        <option value="smart" <?= ($behavior == "smart") ? "selected" : "" ?>><?= _t('ext.readeckButton.configure.behavior_smart'); ?></option>
+        <option value="link" <?= ($behavior == "link") ? "selected" : "" ?>><?= _t('ext.readeckButton.configure.behavior_link'); ?></option>
+        <option value="content" <?= ($behavior == "content") ? "selected" : "" ?>><?= _t('ext.readeckButton.configure.behavior_content'); ?></option>
+      </select>
+      <ul id="behavior_description"><?= _t('ext.readeckButton.configure.behavior_description'); ?></ul>
     </div>
 
     <label class="group-name" for="readeck_button_location"><?= _t('ext.readeckButton.configure.button_location'); ?></label>
@@ -27,14 +37,6 @@ $send_content = FreshRSS_Context::userConf()->attributeString("readeck_content")
         <option value="hidden" <?= ($button_location == "hidden") ? "selected" : "" ?>><?= _t('ext.readeckButton.configure.button_location_hidden'); ?></option>
       </select>
     </div>
-  </div>
-
-  <div class="form-group">
-    <label class="group-name" for="send_content"><?= _t('ext.readeckButton.configure.send_content'); ?></label>
-    <div class="group-controls">
-      <input type="checkbox" name="send_content" id="send_content" <?php echo ($send_content === "on" ? 'checked' : ''); ?> aria-describedby="send_content_description">
-    </div>
-    <p id="send_content_description"><?= _t('ext.readeckButton.configure.send_content_description'); ?></p>
   </div>
 
   <div class="form-group form-actions">

--- a/extension.php
+++ b/extension.php
@@ -39,12 +39,27 @@ class ReadeckButtonExtension extends Minz_Extension
       case "hidden":
         FreshRSS_Context::userConf()->_attribute('readeck_button_location', $button_location);
         FreshRSS_Context::userConf()->save();
-
-        Minz_Request::good(_t('ext.readeckButton.notifications.changes_saved_sucessfully'), $url_redirect);
-        return;
+        break;
       default:
         Minz_Request::bad(_t('ext.readeckButton.notifications.changes_failed', $button_location), $url_redirect);
+        return;
     }
+
+    $readeck_behavior = Minz_Request::paramString('readeck_behavior');
+    switch ($readeck_behavior) {
+      case "smart":
+      case "link":
+      case "content":
+        FreshRSS_Context::userConf()->_attribute('readeck_behavior', $readeck_behavior);
+        FreshRSS_Context::userConf()->save();
+        break;
+      default:
+        Minz_Request::bad(_t('ext.readeckButton.notifications.changes_failed', $readeck_behavior), $url_redirect);
+        return;
+    }
+
+    $url_redirect = array('c' => 'extension');
+    Minz_Request::good(_t('ext.readeckButton.notifications.changes_saved_sucessfully'), $url_redirect);
   }
 
   /**

--- a/extension.php
+++ b/extension.php
@@ -25,6 +25,8 @@ class ReadeckButtonExtension extends Minz_Extension
 
     $keyboard_shortcut = Minz_Request::paramString('readeck_shortcut');
     FreshRSS_Context::userConf()->_attribute('readeck_shortcut', $keyboard_shortcut);
+    $send_content = Minz_Request::paramString('send_content');
+    FreshRSS_Context::userConf()->_attribute('readeck_content', $send_content);
     FreshRSS_Context::userConf()->save();
 
     $button_location = Minz_Request::paramString('readeck_button_location');

--- a/i18n/cs/ext.php
+++ b/i18n/cs/ext.php
@@ -22,7 +22,14 @@ return array(
       'button_location_header_bottom' => 'Horní i spodní řádek',
       'button_location_header' => 'Horní řádek',
       'button_location_bottom' => 'Spodní řádek',
-      'button_location_hidden' => 'Skryté'
+      'button_location_hidden' => 'Skryté',
+      'behavior' => 'Chování',
+      'behavior_smart' => 'Inteligentní',
+      'behavior_link' => 'Odkaz',
+      'behavior_content' => 'Obsah',
+      'behavior_description' => '<li><b>Inteligentní</b> (výchozí) - přepíná mezi starým a novým chováním na základě toho, zda je nastavena autentizace kanálu</li>
+      <li><b>Odkaz</b> (staré chování) - odešle pouze odkaz na článek a nechá Readeck načíst obsah</li>
+      <li><b>Obsah</b> (nové chování) - přímo odešle obsah ze zdroje do Readeck. Užitečné, když jsou články za paywallem, ale ve zdroji jsou kompletní.</li>'
     ),
     'notifications' => array(
       'added_article_to_readeck' => 'Úspěšně přidán <i>\'%s\'</i> do Readecku!',

--- a/i18n/en/ext.php
+++ b/i18n/en/ext.php
@@ -22,7 +22,10 @@ return array(
       'button_location_header_bottom' => 'Top and bottom line',
       'button_location_header' => 'Top line',
       'button_location_bottom' => 'Bottom line',
-      'button_location_hidden' => 'Hidden'
+      'button_location_hidden' => 'Hidden',
+      'send_content' => 'Send feed\'s content',
+      'send_content_description' => 'Rather than having Readeck fetch the article\'s content, this option directly sends the content from the feed to Readeck.
+       It is useful in the case of articles that are behind a paywall but complete in the feed.'
     ),
     'notifications' => array(
       'added_article_to_readeck' => 'Successfully added <i>\'%s\'</i> to Readeck!',

--- a/i18n/en/ext.php
+++ b/i18n/en/ext.php
@@ -23,9 +23,13 @@ return array(
       'button_location_header' => 'Top line',
       'button_location_bottom' => 'Bottom line',
       'button_location_hidden' => 'Hidden',
-      'send_content' => 'Send feed\'s content',
-      'send_content_description' => 'Rather than having Readeck fetch the article\'s content, this option directly sends the content from the feed to Readeck.
-       It is useful in the case of articles that are behind a paywall but complete in the feed.'
+      'behavior' => "Behavior",
+      'behavior_smart' => "Smart",
+      'behavior_link' => "Link",
+      'behavior_content' => "Content",
+      'behavior_description' => '<li><b>Smart</b> (default) - toggles between old and new behavior based on if feed authentication is set up</li>
+      <li><b>Link</b> (old behavior) - sends only article link and lets Readeck fetch the content</li>
+      <li><b>Content</b> (new behavior) - directly sends the content from the feed to Readeck. Useful when articles are behind a paywall but complete in the feed.</li>'
     ),
     'notifications' => array(
       'added_article_to_readeck' => 'Successfully added <i>\'%s\'</i> to Readeck!',


### PR DESCRIPTION
Hello,

I follow multiple publications who put their articles behind paywalls, preventing me from adding them to Readeck using the extension (since it will fetch the content without authentication). However, since these publications provide RSS feeds with full content, I figured that the extension could bypass the paywall by sending the content to Readeck (much like the official browser extension does).

This pull request does just that, with this new behavior behind a checkbox in the extension's settings, in order to not disturb existing users. Ideally, this setting should be set by feed rather than globally, but that is beyond my current understanding of FreshRSS's extension mechanism.

Feel free to critique my code, as my PHP skills are quite basic ;) 