### PR TITLE
feat: add link to bookmark in success notification

### DIFF
--- a/Controllers/readeckButtonController.php
+++ b/Controllers/readeckButtonController.php
@@ -17,7 +17,7 @@ class FreshExtension_readeckButton_Controller extends Minz_ActionController
         'added_to_readeck' => $extension->getFileUrl('added_to_readeck.svg'),
       ),
       'i18n' => array(
-        'added_article_to_readeck' => _t('ext.readeckButton.notifications.added_article_to_readeck', '%s'),
+        'added_article_to_readeck' => _t('ext.readeckButton.notifications.added_article_to_readeck', '%s', '%s'),
         'failed_to_add_article_to_readeck' => _t('ext.readeckButton.notifications.failed_to_add_article_to_readeck', '%s'),
         'ajax_request_failed' => _t('ext.readeckButton.notifications.ajax_request_failed'),
         'article_not_found' => _t('ext.readeckButton.notifications.article_not_found'),
@@ -228,6 +228,7 @@ class FreshExtension_readeckButton_Controller extends Minz_ActionController
 
     return array(
       'response' => json_decode($response_body),
+      'bookmarkId' => $response_headers['bookmark-id'],
       'status' => curl_getinfo($curl, CURLINFO_HTTP_CODE),
       'errorCode' => isset($response_headers['x-error-code'])
         ? intval($response_headers['x-error-code'])

--- a/i18n/cs/ext.php
+++ b/i18n/cs/ext.php
@@ -32,7 +32,7 @@ return array(
       <li><b>Obsah</b> (nové chování) - přímo odešle obsah ze zdroje do Readeck. Užitečné, když jsou články za paywallem, ale ve zdroji jsou kompletní.</li>'
     ),
     'notifications' => array(
-      'added_article_to_readeck' => 'Úspěšně přidán <i>\'%s\'</i> do Readecku!',
+      'added_article_to_readeck' => 'Úspěšně přidán <a href="%s" target="_blank">\'%s\'</a> do Readecku!',
       'failed_to_add_article_to_readeck' => 'Přidání článku na Readeck se nezdařilo! Kód chyby Readeck API: %s',
       'ajax_request_failed' => 'Požadavek Ajax selhal!',
       'authorized_success' => 'Autorizace proběhla úspěšně!',

--- a/i18n/en/ext.php
+++ b/i18n/en/ext.php
@@ -32,7 +32,7 @@ return array(
       <li><b>Content</b> (new behavior) - directly sends the content from the feed to Readeck. Useful when articles are behind a paywall but complete in the feed.</li>'
     ),
     'notifications' => array(
-      'added_article_to_readeck' => 'Successfully added <i>\'%s\'</i> to Readeck!',
+      'added_article_to_readeck' => 'Successfully added <a href="%s" target="_blank">\'%s\'</a> to Readeck!',
       'failed_to_add_article_to_readeck' => 'Adding article to Readeck failed! Readeck API error code: %s',
       'ajax_request_failed' => 'Ajax request failed!',
       'authorized_success' => 'Authorization successful!',

--- a/static/script.js
+++ b/static/script.js
@@ -136,7 +136,10 @@ async function add_to_readeck(readeckButton, active)
         case 202:
         case 301:
           readeckButtonImg.setAttribute("src", readeck_button_vars.icons.added_to_readeck);
-          openNotification(readeck_button_vars.i18n.added_article_to_readeck.replace('%s', json.response.title), 'readeck_button_good');
+          const notificationContent = readeck_button_vars.i18n.added_article_to_readeck
+            .replace('%s', `${readeck_button_vars.instance_url}/bookmarks/${json.bookmarkId}`)
+            .replace('%s', json.response.title);
+          openNotification(notificationContent, 'readeck_button_good');
           break;
 
         case 401:


### PR DESCRIPTION
Hello,

Yet another improvement that I had in the back of my mind: adding the bookmark's URL to the success notification. The idea is that would allow users to update the title or add labels right after the bookmark has been created, emulating what you can do with the browser extension.

To achieve this, I simply read the `bookmark-id` header in the create response, forward it to the Javascript bit and it build the URL and add it to the translation string for the notification.